### PR TITLE
Update documentation and add postgresql deployment to demo TCP connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This will deploy, in the order listed here:
 8. A centralized Gateway for ingress traffic
 9. An HTTPbin application for testing the network
 10. The HTTPRoutes needed to access HTTPbin and Kiali from outside the cluster
+11. A PostgreSQL database to have a TCP based service in the cluster
 
 <!-- TODO: add information about Vault and Cert-Manager -->
 

--- a/README.md
+++ b/README.md
@@ -4,19 +4,60 @@ Repository containing the demo environment and presentation for Kubernetes Gatew
 
 ## Setup
 
-TODO add information about the setups.
+The demo environment we are setting up here utilises `k3d` to setup a 3 node Kubernetes cluster.
+Once the cluster is ready, we use FluxCD to deploy the required infrastructure and applications for
+the demo environment. This is done using the manifests found under [`./demo/flux/`](./demo/flux/).
+This will deploy, in the order listed here:
+
+1. The Gateway API CRDs
+2. Istio CRDs
+3. The Istio CNI
+4. The Istio control plane (`istiod`)
+5. ztunnel for inter-node communication
+6. A Prometheus instance
+7. Kiali, for network visualisation
+8. A centralized Gateway for ingress traffic
+9. An HTTPbin application for testing the network
+10. The HTTPRoutes needed to access HTTPbin and Kiali from outside the cluster
+
+<!-- TODO: add information about Vault and Cert-Manager -->
+
+## Slides
+
+You can find the slides under [`./slides/`](./slides/).
+
+## Demo
+
+Before starting the demo, set up the environment according to the guide in [`./demo/`](./demo/).
+
+> [!NOTE]
+> The initial setup already makes use of the Gateway API to expose Kiali and HTTPbin. For this, it
+> uses a GatewayClass provided by Istio, a centralized Gateway shared across namespaces, and two
+> HTTPRoutes routing traffic to the corresponding Kubernetes Services of the applications.
+
+### Initial Investigation
+
+<!-- TODO: add commands to check gateway resources deployed -->
+
+### Gateway Deployment
+
+<!-- TODO: deploy a new gateway to port 81 to expose other traffic -->
+
+### HTTPRoutes
+
+<!-- TODO: expose HTTPbin via new Gateway -->
+
+### TCPRoutes
+
+<!-- TODO: expose psql via new Gateway -->
+
+### Routing Options
+
+<!-- TODO: modify routes to show new capabilities -->
 
 ## Idea
 
-### Presentation
-
-Content:
-
-- what are ingresses, providers (nginx, traefik)
-- what are routes
-- what are service meshes, providers (istio, cilium)
-- what is the gateway api, providers (https://gateway-api.sigs.k8s.io/implementations/)
-- how is it different from ingress/route?
+<!-- TODO: remove this section once we have the demo -->
 
 ### Demo
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -42,6 +42,13 @@ following command to return a pod to ensure most of the infrastructure is ready:
 kubectl get pods -n infra-gateway-system -l service.istio.io/canonical-name=prod-gateway-istio
 ```
 
+To ensure the app is also ready, ensure the following command also returns a pod (might take up to
+5-10 minutes, depending on your internet connection to pull images):
+
+```bash
+kubectl get pods -n httpbin
+```
+
 ### Access
 
 Change your `/etc/hosts` file to contain an entry for routing traffic to the cluster:

--- a/demo/devbox.json
+++ b/demo/devbox.json
@@ -6,7 +6,8 @@
     "kubectl@1.31.0",
     "kubernetes-helm@3.16.1",
     "fluxcd@2.3.0",
-    "k3d@5.7.4"
+    "k3d@5.7.4",
+    "postgresql@16.4"
   ],
   "shell": {
     "init_hook": [],

--- a/demo/devbox.lock
+++ b/demo/devbox.lock
@@ -277,6 +277,131 @@
         }
       }
     },
+    "postgresql@16.4": {
+      "last_modified": "2024-10-06T02:39:15Z",
+      "plugin_version": "0.0.2",
+      "resolved": "github:NixOS/nixpkgs/7d49afd36b5590f023ec56809c02e05d8164fbc4#postgresql",
+      "source": "devbox-search",
+      "version": "16.4",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/fln3gcl40fwynfjr5fkpyqjhll4jqyhm-postgresql-16.4",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/npkdasdws60qy0j0kznqwnbizcjx5m0q-postgresql-16.4-man",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/63r8cs0kjscq50r93k97aijddx2mjwm9-postgresql-16.4-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/akn2wpw56q2cwwpa3kdd4isklaqk375s-postgresql-16.4-doc"
+            },
+            {
+              "name": "lib",
+              "path": "/nix/store/5i4svw3nbn239hhzrl857bkbqb5h1aq1-postgresql-16.4-lib"
+            }
+          ],
+          "store_path": "/nix/store/fln3gcl40fwynfjr5fkpyqjhll4jqyhm-postgresql-16.4"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/7bm8jppsyml2lkzzbw5kg6ahmvwlnxsb-postgresql-16.4",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/4i96xjnrsxgcpizmr6v7gmc25zminnl2-postgresql-16.4-man",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/w6hs71a695sf2n00km946bb1v36xc2qg-postgresql-16.4-debug"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/ycbf1qw3x8wc3a7z6mjwkzmyhc43s2wn-postgresql-16.4-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/bh5km6cln45kf1pfwahdslpc9cydrm4v-postgresql-16.4-doc"
+            },
+            {
+              "name": "lib",
+              "path": "/nix/store/3crpddg2akfnpg19plbbfyxny13ygdaf-postgresql-16.4-lib"
+            }
+          ],
+          "store_path": "/nix/store/7bm8jppsyml2lkzzbw5kg6ahmvwlnxsb-postgresql-16.4"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/ywikp0nf87afr4qs2dvjxiknwzyf6n5b-postgresql-16.4",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/n66gp6v6zd5fxwh2j72jjx5d427fpibp-postgresql-16.4-man",
+              "default": true
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/ayarhx2gw8y5j648r4jfsl8l54s5nb8i-postgresql-16.4-doc"
+            },
+            {
+              "name": "lib",
+              "path": "/nix/store/k5n25gjgfbxwyjhzf2il0b93q18gdsr7-postgresql-16.4-lib"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/sb23d37zmmymsn268d9lcpgd0j939117-postgresql-16.4-dev"
+            }
+          ],
+          "store_path": "/nix/store/ywikp0nf87afr4qs2dvjxiknwzyf6n5b-postgresql-16.4"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/1gax5xs6h1b70gk7z274kx4qh04hsn96-postgresql-16.4",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/43pzfj4xv6r022jmnmx2n648ycqy8rhx-postgresql-16.4-man",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/isrqqmd5ckwwsgk708q981h3h7ijixkv-postgresql-16.4-debug"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/45if5nl708nhayxnaqh7h2scz9pn4mn8-postgresql-16.4-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/plf9diy9a5l5fmfl8pvlgmpxkc3ixhb3-postgresql-16.4-doc"
+            },
+            {
+              "name": "lib",
+              "path": "/nix/store/l54jqbzqhghvy3g9kqhmcha9z3vzzrxr-postgresql-16.4-lib"
+            }
+          ],
+          "store_path": "/nix/store/1gax5xs6h1b70gk7z274kx4qh04hsn96-postgresql-16.4"
+        }
+      }
+    },
     "vault-bin@1.17.5": {
       "last_modified": "2024-09-15T10:42:20Z",
       "resolved": "github:NixOS/nixpkgs/76d7694a3f681b0b750c01783df5d2177ef39fe7#vault-bin",

--- a/demo/flux/bitnami-postgresql-oci-repository.yaml
+++ b/demo/flux/bitnami-postgresql-oci-repository.yaml
@@ -1,0 +1,10 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: bitnami-postgresql
+  namespace: postgresql
+spec:
+  interval: 24h
+  url: oci://registry-1.docker.io/bitnamicharts/postgresql
+  ref:
+    tag: "16.0.1"

--- a/demo/flux/kustomization.yaml
+++ b/demo/flux/kustomization.yaml
@@ -2,8 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  # gateway api resources
-  - https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.1.0/standard-install.yaml
+  # gateway api resources (experimental - allows to use TCPRoute, TLSRoute, etc).
+  - https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/experimental-install.yaml
   # istio ambient mode setup
   - istio-namespace.yaml
   - istio-repository.yaml

--- a/demo/flux/kustomization.yaml
+++ b/demo/flux/kustomization.yaml
@@ -24,3 +24,7 @@ resources:
   - matheusfm-repository.yaml
   - httpbin-release.yaml
   - httpbin-httproute.yaml
+  # postgresql
+  - postgresql-namespace.yaml
+  - bitnami-postgresql-oci-repository.yaml
+  - postgresql-release.yaml

--- a/demo/flux/postgresql-namespace.yaml
+++ b/demo/flux/postgresql-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: postgresql

--- a/demo/flux/postgresql-release.yaml
+++ b/demo/flux/postgresql-release.yaml
@@ -1,0 +1,20 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: postgresql
+  namespace: postgresql
+spec:
+  interval: "5m"
+  install:
+    createNamespace: true
+  chartRef:
+    kind: OCIRepository
+    name: bitnami-postgresql
+  values:
+    global:
+      postgresql:
+        auth:
+          postgresPassword: postgres
+          username: demo
+          password: demo
+          database: demo

--- a/slides/README.md
+++ b/slides/README.md
@@ -2,6 +2,21 @@
 
 A repository containing all my presentations.
 
+## Idea
+
+<!-- TODO: remove this section once we have the slides -->
+
+### Presentation
+
+Content:
+
+- what are ingresses, providers (nginx, traefik)
+- what are routes
+- what are service meshes, providers (istio, cilium)
+- what is the gateway api, providers (https://gateway-api.sigs.k8s.io/implementations/)
+- GAMMA initiative
+- how is it different from ingress/route?
+
 ## Generating Slides
 
 Slides can be generated using the Tupfile once in the Devbox shell:


### PR DESCRIPTION
This PR does:

- use experimental Gateway API deployment to allow TCPRoute and TLSRoute usage.
- update documentation on what we do and how.
- deploy a postgresql database via bitnami OCI chart artefact with minimal pre-configuration

Closes #4 